### PR TITLE
Do nothing when resource has no title

### DIFF
--- a/mod_rsc_name.erl
+++ b/mod_rsc_name.erl
@@ -34,9 +34,14 @@ observe_rsc_update(#rsc_update{id=Id, props=AllProps}, {Changed, UpdateProps}, C
     case z_utils:is_empty(proplists:get_value(name, UpdateProps)) andalso
          z_utils:is_empty(proplists:get_value(name, AllProps)) of
         true ->
-            Title = z_trans:trans(proplists:get_value(title, UpdateProps ++ AllProps), Context),
-            Name = calculate_name(Id, 0, Title, Context),
-            {true, [{name, Name} | proplists:delete(name, UpdateProps)]};
+            case proplists:get_value(title, UpdateProps ++ AllProps) of
+                undefined ->
+	            {Changed, UpdateProps};
+                Title ->
+		    z_trans:trans(Title, Context),
+            	    Name = calculate_name(Id, 0, Title, Context),
+                    {true, [{name, Name} | proplists:delete(name, UpdateProps)]}
+            end;
         false ->
             {Changed, UpdateProps}
     end.                


### PR DESCRIPTION
This fixes:

```
warning @ controller_websocket:142
throw:{badarg,[{erlang,iolist_to_binary,[[undefined," ",[]]],[]},
               {mod_rsc_name,calculate_name,4,
                             [{file,"priv/modules/mod_rsc_name/mod_rsc_name.erl"},
                              {line,59}]},
               {mod_rsc_name,observe_rsc_update,3,
                             [{file,"priv/modules/mod_rsc_name/mod_rsc_name.erl"},
                              {line,40}]},
               {m_rsc_update,'-update/4-fun-1-',7,
                             [{file,"src/models/m_rsc_update.erl"},
                              {line,273}]},
               {z_db,transaction,3,
                     [{file,"src/dbdrivers/postgresql/z_db.erl"},{line,83}]},
               {m_rsc_update,update,4,
                             [{file,"src/models/m_rsc_update.erl"},
                              {line,306}]},
               {mod_oembed,preview_create,3,
                           [{file,"modules/mod_oembed/mod_oembed.erl"},
                            {line,326}]},
               {mod_oembed,observe_rsc_update,3,
                           [{file,"modules/mod_oembed/mod_oembed.erl"},
                            {line,79}]}]}
```
